### PR TITLE
Tolerate missing PNC/NullSites CSVs in chart loader

### DIFF
--- a/client/src/ReasonTrendsChart.jsx
+++ b/client/src/ReasonTrendsChart.jsx
@@ -256,8 +256,8 @@ export default function ReasonTrendsChart({
 
                 const [allData, pncData, nullData] = await Promise.all([
                   parseCsv(allPath),
-                  parseCsv(pncPath),
-                  parseCsv(nullPath),
+                  parseCsv(pncPath).catch(() => null),
+                  parseCsv(nullPath).catch(() => null),
                 ]);
 
                 const hasSchemaColumn = allData.headers.includes(
@@ -278,8 +278,8 @@ export default function ReasonTrendsChart({
                 return {
                   key: monthKey,
                   allRecords,
-                  pncRows: pncData.rows,
-                  nullRows: nullData.rows,
+                  pncRows: pncData ? pncData.rows : null,
+                  nullRows: nullData ? nullData.rows : null,
                   hasSchemaColumn,
                   parseErrors,
                 };


### PR DESCRIPTION
On the deployed site, the schema-classification chart shows "Schema mode unavailable" even though every monthly all-data CSV has the `compliance_classification` column.

PR #54 removed the `PotentiallyNonCompliantSites*.csv` and `NullSites*.csv` files, but `ReasonTrendsChart.jsx` still fetches all three (all/PNC/Null) per state-month inside one `Promise.all`. Vercel 404s the missing files, PapaParse rejects, and the whole load aborts before `stateMonthToSchemaAvailability` is populated. Vite's dev/preview server hid this — it serves the SPA `index.html` fallback with 200 for missing paths, so PapaParse "parses" HTML as CSV and resolves.

Fix: catch errors on the PNC/Null `parseCsv` calls and pass `null` through. Downstream `Array.isArray` guards already handle it, so those series render as gaps and the schema chart works.