### PR TITLE
Fixed lines in multistate graphs not spanning gaps

### DIFF
--- a/client/src/ReasonTrendsChart.jsx
+++ b/client/src/ReasonTrendsChart.jsx
@@ -357,6 +357,7 @@ const ReasonTrendsChart = memo(function ReasonTrendsChart({ analysisMode, timePe
         data, borderColor: color, backgroundColor: chartType === "line" ? color : `${color}80`,
         fill: false, tension: 0.3, pointRadius: 4, pointHoverRadius: 6,
         borderRadius: chartType === "bar" ? { topLeft: 8, topRight: 8 } : 0,
+        spanGaps: true,
       });
     }));
     return allDatasets;


### PR DESCRIPTION
The graph creation just required one line: "spanGaps: true".  This solved the issue and everything else runs the same. Here is the deployed graph for all 4 states vs this version.
<img width="2652" height="1000" alt="Trend_schema_CA_CT_CO_NJ" src="https://github.com/user-attachments/assets/a75fbde7-62a6-452b-b2ee-814f768e1e0f" />
<img width="2652" height="1000" alt="Trend_schema_CA_CT_CO_NJ (1)" src="https://github.com/user-attachments/assets/e10d60bb-498b-4d9d-ab34-00dd8d8815ff" />

I will continue to look into getting different colors for each state line and potentially using a time-proportional x-axis. I just wanted to get out this quick bug fix.

(issue #82)