### PR TITLE
Implemented 'ui-major' group for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,13 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      client-minor-and-patch:
+      ui-minor-and-patch:
         update-types:
           - minor
           - patch
+      ui-major:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve and enable auto-merge for patch and minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.metadata.outputs.dependency-group == 'ui-minor-and-patch'
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
### Overview
This PR makes the WebUI group updates exactly like with OptMeowt and the WebCrawler. That is to say:
- Major updates are grouped for manual verification + merging
- Minor and Patch updates are grouped and merged automatically

### Small Note
The previous name for the Minor and Patch updates was "client-minor-and-patch" which I renamed to "ui-minor-and-patch". This was done to maintain the naming convention established in the other repos. 

I'm also aware we likely won't be able to merge this PR until the current Vercel issue (#80) is resolved, but I thought I'd push this now so as to not forget and cause confusion down the line. (Scratch that, everything was just merged succesfully!)