### PR TITLE
UI quality of life improvements: chart toggle, color consistency, and line shading

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -246,7 +246,7 @@ function App() {
   const [visibleColumns, setVisibleColumns] = useState([]);
   const [showColumnPicker, setShowColumnPicker] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-
+  const [activeChart, setActiveChart] = useState("trends");
   useEffect(() => {
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
@@ -692,37 +692,56 @@ function App() {
         </div>
       )}
 
-      <ReasonTrendsChart
-        analysisMode={analysisMode}
-        timePeriods={TIME_PERIODS}
-        stateMonths={STATE_MONTHS}
-      />
+      <div style={{ display: "flex", justifyContent: "center", gap: "8px", margin: "16px 0 0" }}>
+        <button
+          className={`chip${activeChart === "trends" ? " chip--active" : ""}`}
+          onClick={() => setActiveChart("trends")}
+        >
+          Compliance Trends
+        </button>
+        <button
+          className={`chip${activeChart === "gpp" ? " chip--active" : ""}`}
+          onClick={() => setActiveChart("gpp")}
+        >
+          GPP Breakdown
+        </button>
+      </div>
 
-      <LazyOnView
-        fallback={
-          <div
-            className="card card--padded section"
-            style={{ minHeight: 360 }}
-            aria-hidden="true"
-          />
-        }
-      >
-        <Suspense
+      {activeChart === "trends" && (
+        <ReasonTrendsChart
+          analysisMode={analysisMode}
+          timePeriods={TIME_PERIODS}
+          stateMonths={STATE_MONTHS}
+        />
+      )}
+
+      {activeChart === "gpp" && (
+        <LazyOnView
           fallback={
             <div
               className="card card--padded section"
               style={{ minHeight: 360 }}
-            >
-              <p className="muted-text">Loading GPP breakdown…</p>
-            </div>
+              aria-hidden="true"
+            />
           }
         >
-          <GppSectionBreakdownChart
-            timePeriods={TIME_PERIODS}
-            stateMonths={STATE_MONTHS}
-          />
-        </Suspense>
-      </LazyOnView>
+          <Suspense
+            fallback={
+              <div
+                className="card card--padded section"
+                style={{ minHeight: 360 }}
+              >
+                <p className="muted-text">Loading GPP breakdown…</p>
+              </div>
+            }
+          >
+            <GppSectionBreakdownChart
+              timePeriods={TIME_PERIODS}
+              stateMonths={STATE_MONTHS}
+            />
+          </Suspense>
+        </LazyOnView>
+      )}
 
       <h2 className="section-title">Filter GPC Web Crawler Data</h2>
       <div className="toolbar" role="group" aria-label="Data filters">

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -694,28 +694,38 @@ function App() {
 
       <div style={{ display: "flex", justifyContent: "center", gap: "8px", margin: "16px 0 0" }}>
         <button
-          className={`chip${activeChart === "trends" ? " chip--active" : ""}`}
+          className="chip"
           onClick={() => setActiveChart("trends")}
+          disabled={activeChart === "trends"}
+          style={{
+            opacity: activeChart === "trends" ? 0.5 : 1,
+            cursor: activeChart === "trends" ? "default" : "pointer",
+          }}
         >
           Compliance Trends
         </button>
         <button
-          className={`chip${activeChart === "gpp" ? " chip--active" : ""}`}
+          className="chip"
           onClick={() => setActiveChart("gpp")}
+          disabled={activeChart === "gpp"}
+          style={{
+            opacity: activeChart === "gpp" ? 0.5 : 1,
+            cursor: activeChart === "gpp" ? "default" : "pointer",
+          }}
         >
           GPP Breakdown
         </button>
       </div>
 
-      {activeChart === "trends" && (
+      <div style={{ display: activeChart === "trends" ? "block" : "none" }}>
         <ReasonTrendsChart
           analysisMode={analysisMode}
           timePeriods={TIME_PERIODS}
           stateMonths={STATE_MONTHS}
         />
-      )}
+      </div>
 
-      {activeChart === "gpp" && (
+      <div style={{ display: activeChart === "gpp" ? "block" : "none" }}>
         <LazyOnView
           fallback={
             <div
@@ -741,7 +751,7 @@ function App() {
             />
           </Suspense>
         </LazyOnView>
-      )}
+      </div>
 
       <h2 className="section-title">Filter GPC Web Crawler Data</h2>
       <div className="toolbar" role="group" aria-label="Data filters">

--- a/client/src/ReasonTrendsChart.jsx
+++ b/client/src/ReasonTrendsChart.jsx
@@ -310,6 +310,20 @@ const ReasonTrendsChart = memo(function ReasonTrendsChart({ analysisMode, timePe
   const datasets = useMemo(() => {
     if (selectedSeries.length === 0) return [];
     const allDatasets = []; const statusVarCounters = {};
+    const colorUsageCounts = {};
+    selectedStates.forEach(s => selectedSeries.forEach(sk => {
+      let c;
+      if (sk === SPECIAL_SERIES.PNC_SITES) c = getColorForSeries(SPECIAL_SERIES.PNC_SITES);
+      else if (sk === SPECIAL_SERIES.NULL_SITES) c = getColorForSeries(SPECIAL_SERIES.NULL_SITES);
+      else {
+        const statusKey = parseSchemaToken(sk)?.status ?? "__legacy";
+        const palette = STATUS_COLOR_PALETTES[statusKey] ?? LEGACY_COLOR_PALETTE;
+        c = palette[0];
+      }
+      colorUsageCounts[c] = (colorUsageCounts[c] || 0) + 1;
+    }));
+
+    const colorIndexCounters = {};
     selectedStates.forEach(stateCode => selectedSeries.forEach(seriesKey => {
       let baseColor;
       if (seriesKey === SPECIAL_SERIES.PNC_SITES) baseColor = getColorForSeries(SPECIAL_SERIES.PNC_SITES);
@@ -323,11 +337,18 @@ const ReasonTrendsChart = memo(function ReasonTrendsChart({ analysisMode, timePe
       }
 
       let color = baseColor;
-      if (selectedSeries.length <= 2 && selectedStates.length > 1) {
+      const colorIdx = colorIndexCounters[baseColor] ?? 0;
+      colorIndexCounters[baseColor] = colorIdx + 1;
+      const colorTotal = colorUsageCounts[baseColor] ?? 1;
+      if (selectedStates.length > 1) {
         const n = selectedStates.length;
         const i = Math.max(0, selectedStates.indexOf(stateCode));
         const spread = n > 1 ? (i / (n - 1)) : 0.5;
-        const percent = (spread - 0.5) * 0.6; 
+        const percent = (spread - 0.5) * 0.6;
+        color = shadeHex(baseColor, percent);
+      } else if (colorTotal > 1) {
+        const spread = colorIdx / (colorTotal - 1);
+        const percent = (spread - 0.5) * 0.6;
         color = shadeHex(baseColor, percent);
       }
 

--- a/client/src/components/SchemaFilterPanel.jsx
+++ b/client/src/components/SchemaFilterPanel.jsx
@@ -268,17 +268,20 @@ function GppCard({ tokens, selectedSet, onToggleFamily, onAdd, onRemove, labels,
                                   position="top"
                                 >
                                   <button
-                                    className={[
-                                      "sfp__status-pill sfp__status-pill--sm",
-                                      cls,
-                                      active ? "sfp__status-pill--on" : "",
-                                    ].join(" ")}
-                                    onClick={() =>
-                                      toggleSingleToken(token, active)
-                                    }
-                                  >
-                                    {sl}
-                                  </button>
+                                  className={[
+                                    "sfp__status-pill sfp__status-pill--sm",
+                                    cls,
+                                    active ? "sfp__status-pill--on" : "",
+                                  ].join(" ")}
+                                  onClick={() => toggleSingleToken(token, active)}
+                                  style={{
+                                    borderColor: (STATUS_COLOR_PALETTES[sk] && STATUS_COLOR_PALETTES[sk][0]) || undefined,
+                                    color: active ? undefined : (STATUS_COLOR_PALETTES[sk] && STATUS_COLOR_PALETTES[sk][0]) || undefined,
+                                    background: active ? (STATUS_COLOR_PALETTES[sk] && STATUS_COLOR_PALETTES[sk][0]) || undefined : undefined,
+                                  }}
+                                >
+                                  {sl}
+                                </button>
                                 </Tooltip>
                               );
                             })}


### PR DESCRIPTION
This PR makes a few small quality of life improvements to the UI across three areas: a chart toggle, a color consistency fix, and improved line shading.

In our last meeting we discussed keeping the focus on the compliance trends graph, as having both charts visible at once can be slightly confusing since editing settings on one graph doesn't impact the other. A toggle was added above the charts so users can switch between the "Track Compliance Evolution Over Time" and "GPP Compliance Before and After GPC" views, preserving the functionality of the GPP breakdown chart without making it a focal point of the page. The active button is greyed out to indicate which view is currently selected, and chart settings are preserved when switching between views.

The remaining two changes are extensions of PR #89. The first is a small gap in that PR's bug fix where the GPP expanded field detail pills were not included in the color palette sync and were still displaying the wrong colors (e.g. Invalid/Missing appearing orange instead of blue). The second applies the same color shading logic used to differentiate lines across multiple states to single-state graphs with multiple variables sharing the same base color, making individual series easier to distinguish.